### PR TITLE
Set Icon Size to Fill Room on Map

### DIFF
--- a/maps/maps.jsonc
+++ b/maps/maps.jsonc
@@ -2,60 +2,70 @@
   {
     "name": "sw",
     "location_size": 12,
+    "location_icon_size": 24,
     "location_border_thickness": 4,
     "img": "images/maps/southern_woodland.png"
   },
   {
     "name": "wc",
     "location_size": 12,
+    "location_icon_size": 24,
     "location_border_thickness": 4,
     "img": "images/maps/western_coast.png"
   },
   {
     "name": "ic",
     "location_size": 12,
+    "location_icon_size": 24,
     "location_border_thickness": 4,
     "img": "images/maps/island_core.png"
   },
   {
     "name": "nt",
     "location_size": 12,
+    "location_icon_size": 24,
     "location_border_thickness": 4,
     "img": "images/maps/northern_tundra.png"
   },
   {
     "name": "eh",
     "location_size": 12,
+    "location_icon_size": 24,
     "location_border_thickness": 4,
     "img": "images/maps/eastern_highlands.png"
   },
   {
     "name": "rrt",
     "location_size": 12,
+    "location_icon_size": 24,
     "location_border_thickness": 4,
     "img": "images/maps/rabi_rabi_town.png"
   },
   {
     "name": "p",
     "location_size": 12,
+    "location_icon_size": 24,
     "location_border_thickness": 4,
     "img": "images/maps/plurkwood.png"
   },
   {
     "name": "sa",
     "location_size": 12,
+    "location_icon_size": 24,
     "location_border_thickness": 4,
     "img": "images/maps/subterranean_area.png"
   },
   {
     "name": "wd",
     "location_size": 12,
+    "location_icon_size": 24,
     "location_border_thickness": 4,
     "img": "images/maps/warp_destination.png"
   },
   {
     "name": "si",
     "location_size": 12,
+    "location_icon_size": 24,
     "location_border_thickness": 4,
     "img": "images/maps/system_interior.png"
   }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ffc23f46-331a-4b51-ac8c-38228c702672)
Player location tracking uses the property `location_icon_size` for the size of the icon displayed on the map, defaulting to the location size if not present.

The current `location_size` for each map is 12, which is rather small for the player icon, so I updated the maps to include a `location_icon_size`

When the UT changes are added to the APWorld, poptracker should be able to auto tab to the current map and display Erina's location by pulling from the following keys:
`{slot}_{team}_rabi_ribi_area_id` (zero-indexed map ID, should match with poptracker already)
`{slot}_{team}_rabi_ribi_coords` (the current room, given by the offset from the top left corner of the in game map.)

The APWorld is using the following offsets to position the player icon correctly, but we're also subtracting 16 pixels from the X and Y after to center, so these could all be considered off by 1:

```python
MAP_OFFSETS = [
    (1, 2), # Southern Woodland
    (1, 3), # Western Coast
    (3, 3), # Island Core
    (2, 2), # Northern Tundra
    (1, 2), # Eastern Highlands
    (2, 0), # Rabi Rabi Town
    (1, 2), # Plurkwood
    (1, 2), # Subterranean Area
    (0, 5), # Warp Destination
    (1, 2), # System Interior
]
```